### PR TITLE
#21 Bugfix - Fix our lessons section center alignment

### DIFF
--- a/src/css/layout/lessons.css
+++ b/src/css/layout/lessons.css
@@ -73,6 +73,12 @@
 	}
 }
 
+@media screen and (min-width: 1280px) {
+	.lessons-list {
+		justify-content: center;
+	}
+}
+
 .lessons-list-card {
 	width: 100%;
 	padding: 40px 20px;


### PR DESCRIPTION
Виправив вирівнювання по центру для секції out lessons.

Виправлення стосується лише десктоп версії.
Для мобілок та планшету контент має заповнює 100 % ширини контейнеру - **потрібно уточнити це питання для в'юпорту 320 px, як раніше не працювало**.